### PR TITLE
fix: When the profile is empty, and base64 avatar problem

### DIFF
--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@us3r-network/profile",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "the us3r profile components",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/profile/src/ProfileStateProvider.tsx
+++ b/packages/profile/src/ProfileStateProvider.tsx
@@ -74,11 +74,7 @@ export default function ProfileStateProvider({
       s3ProfileModel
         .queryPersonalProfile()
         .then((res) => {
-          if (res?.errors && res.errors.length > 0) {
-            setProfile(defaultNewProfile);
-          } else {
-            setProfile(res.data?.viewer?.profile || null);
-          }
+          setProfile(res.data?.viewer?.profile || defaultNewProfile);
         })
         .finally(() => {
           setProfileLoading(false);

--- a/packages/profile/src/ProfileStateProvider.tsx
+++ b/packages/profile/src/ProfileStateProvider.tsx
@@ -110,15 +110,16 @@ export default function ProfileStateProvider({
       if (!session || !s3ProfileModalAuthed || !s3ProfileModel) {
         throw Error("updateProfile: not authed");
       }
-      const newProfile = { ...profile, ...data };
 
-      const res = await s3ProfileModel.mutationPersonalProfile({
-        name: newProfile.name || shortDid(session.id),
-        avatar: newProfile.avatar || "",
-        bio: newProfile.bio || "bio",
-        tags: [...(newProfile.tags || [])],
-        wallets: [...(newProfile.wallets || [])],
-      });
+      const newProfile = {
+        name: data?.name || profile?.name || shortDid(session.id),
+        avatar: data?.avatar || profile?.avatar || "",
+        bio: data?.bio || profile?.bio || "bio",
+        tags: [...(data.tags || profile?.tags || [])],
+        wallets: [...(data.wallets || profile?.wallets || [])],
+      };
+
+      const res = await s3ProfileModel.mutationPersonalProfile(newProfile);
 
       if (res?.errors && res.errors.length > 0) {
         throw Error(res.errors[0].message);

--- a/packages/profile/src/ProfileStateProvider.tsx
+++ b/packages/profile/src/ProfileStateProvider.tsx
@@ -115,8 +115,8 @@ export default function ProfileStateProvider({
         name: data?.name || profile?.name || shortDid(session.id),
         avatar: data?.avatar || profile?.avatar || "",
         bio: data?.bio || profile?.bio || "bio",
-        tags: [...(data.tags || profile?.tags || [])],
-        wallets: [...(data.wallets || profile?.wallets || [])],
+        tags: [...(data?.tags || profile?.tags || [])],
+        wallets: [...(data?.wallets || profile?.wallets || [])],
       };
 
       const res = await s3ProfileModel.mutationPersonalProfile(newProfile);

--- a/packages/profile/src/components/UserInfo/edit-form/UserInfoEditForm.tsx
+++ b/packages/profile/src/components/UserInfo/edit-form/UserInfoEditForm.tsx
@@ -13,8 +13,6 @@ import {
   UserInfoEditFormContextValue,
 } from "./UserInfoEditFormContext";
 import { UserInfoEditFormDefaultChildren } from "./UserInfoEditFormDefaultChildren";
-import { getDefaultUserAvatarWithDid } from "../../../utils/avatar";
-import { useSession } from "@us3r-network/auth-with-rainbowkit";
 
 export interface AvatarUploadOpts<T> {
   /**
@@ -57,7 +55,6 @@ function UserInfoEditFormRoot<T>({
   onSuccessfullySubmit,
   ...props
 }: UserInfoEditFormProps<T>) {
-  const session = useSession();
   const { profile, profileLoading, updateProfile } = useProfileState();
 
   const [avatar, setAvatar] = useState("");
@@ -80,9 +77,9 @@ function UserInfoEditFormRoot<T>({
 
   useEffect(() => {
     if (!isUpdating) {
-      setAvatar(profile?.avatar || getDefaultUserAvatarWithDid(session?.id));
+      setAvatar(profile?.avatar || "");
     }
-  }, [session, profile?.avatar, isUpdating]);
+  }, [profile?.avatar, isUpdating]);
 
   useEffect(() => {
     setErrMsg("");

--- a/packages/profile/src/components/UserInfo/edit-form/UserInfoEditFormElements.tsx
+++ b/packages/profile/src/components/UserInfo/edit-form/UserInfoEditFormElements.tsx
@@ -12,6 +12,8 @@ import { HTMLAttributes, useMemo } from "react";
 import { TextArea, TextAreaProps } from "../../common/TextArea";
 import { ChildrenRenderProps, childrenRender } from "../../../utils/props";
 import LoadingSpokes from "../../common/Loading/LoadingSpokes";
+import { useSession } from "@us3r-network/auth-with-rainbowkit";
+import { getDefaultUserAvatarWithDid } from "../../../utils/avatar";
 
 type AvatarFieldRenderProps = {
   isLoading: boolean;
@@ -82,10 +84,15 @@ function AvatarFieldDefaultChildren({
 
 function AvatarPreviewImg(props: HTMLAttributes<HTMLImageElement>) {
   const { avatar } = useUserInfoEditFormState();
+  const session = useSession();
+  const imgSrc = useMemo(
+    () => avatar || getDefaultUserAvatarWithDid(session?.id),
+    [avatar, session]
+  );
   return (
     <img
       data-state-element="AvatarPreviewImg"
-      src={avatar}
+      src={imgSrc}
       width={32}
       height={32}
       {...props}


### PR DESCRIPTION
1. 新用户profile为空时无法编辑表单
2. avatar 值为base64 的bug修复